### PR TITLE
Multiple loggers of winston-transport-sequelize

### DIFF
--- a/winston-transport-sequelize.js
+++ b/winston-transport-sequelize.js
@@ -5,7 +5,7 @@ var util = require('util');
 var SequelizeTransport = module.exports = function (options) {
     this.options = options || {};
     
-    this.name = 'sequelize';
+    this.name = options.name || 'sequelize';
     this.level = options.level || 'error';
     
     if (!this.options.tableName) {


### PR DESCRIPTION
Hello! I want multiple loggers with type winston-transport-sequelize
Like so:
let winstonOptions = {
    transports: [
        new (winston.transports.Sequelize)({
            sequelize: sequelize,
            tableName: 'WarningsLog',
            level: 'warn'
        }),
        new (winston.transports.Sequelize)({
            sequelize: sequelize,
            tableName: 'ErrorsLog',
            level: 'error'
        })
    ],
    exitOnError: false
};

but winston throws error 'Error: Transport already attached: sequelize, assign a different name'

to solve this issue I suppose replace
this.name = 'sequelize'  to  this.name = options.name || 'sequelize'

and then it will work like so:

let warningsLogger = new winston.transports.Sequelize({
    name: 'postgres.warnings',
    sequelize: sequelize,
    tableName: 'WarningsLog',
    level: 'warn'
});

let errorsLogger = new (winston.transports.Sequelize)({
    name: 'postgres.errors',
    sequelize: sequelize,
    tableName: 'ErrorsLog',
    level: 'error'
});

let winstonOptions = {
    transports: [
        debugLogger,
        warningsLogger,
        errorsLogger
    ],
    exitOnError: false
};

Note 'name' in options

useful link https://github.com/winstonjs/winston/pull/187