### PR TITLE
Add environment and application to log info

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,12 @@ class SequelizeTransport extends winston.Transport {
       }
 
       data.meta = meta;
-      data.application = this.options.application;
-      data.environment = this.options.environment;
+      if(this.options.application) {
+        data.application = this.options.application;
+      }
+      if(this.options.environment) {
+        data.environment = this.options.environment;
+      }
 
       this.model.create(data).then((log) => {
         this.emit('logged');

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ class SequelizeTransport extends winston.Transport {
         get: function () {
           return JSON.parse(this.getDataValue('meta'));
         }
-      }
+      },
+      application: Sequelize.STRING,
+      environment: Sequelize.STRING,
     }, options.fields || {});
 
     const modelOptions = Object.assign({
@@ -64,6 +66,8 @@ class SequelizeTransport extends winston.Transport {
       }
 
       data.meta = meta;
+      data.application = this.options.application;
+      data.environment = this.options.environment;
 
       this.model.create(data).then((log) => {
         this.emit('logged');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-transport-sequelize",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hi - I forked and made a change which may be useful - I've added columns for Application and Environment, which is useful for our implementation where we are logging 'audit' level logs to a central location for various applications. 